### PR TITLE
add step in iso workflow to remove unused software

### DIFF
--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -59,6 +59,8 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Maximize build space
+        uses: ublue-os/remove-unwanted-software@v6
       - name: Build ISO
         shell: bash
         run: |


### PR DESCRIPTION
free up space as some builds require having as much space as possible