### PR TITLE
fix: make loop device during container build of ISO

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,4 +21,4 @@ RUN dnf install -y make && make install-deps
 
 VOLUME /isogenerator/output
 
-ENTRYPOINT ["sh", "-c", "make output/${IMAGE_NAME}-${IMAGE_TAG}.iso ARCH=${ARCH} VERSION=${VERSION} IMAGE_REPO=${IMAGE_REPO} IMAGE_NAME=${IMAGE_NAME} IMAGE_TAG=${IMAGE_TAG} VARIANT=${VARIANT} WEB_UI=${WEB_UI}"]
+ENTRYPOINT /isogenerator/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -16,14 +16,22 @@ This will create an ISO with the baked in defaults of the container image.
 See [Customizing](#customizing) for information about customizing the image that gets created. The variable can either be defined as environment variables or as command arguments.
 Examples:
 
-Creating Bluefin GTS ISO
+Creating Universal Blue Silverblue ISO
 ```bash
-docker run --rm --privileged --volume .:/isogenerator/output -e VERSION=38 -e IMAGE_NAME=bluefin -e IMAGE_TAG=gts -e VARIANT=Silverblue ghcr.io/ublue-os/isogenerator:38
+docker run --rm --privileged --volume .:/isogenerator/output -e VERSION=39 -e IMAGE_NAME=silverblue-main -e IMAGE_TAG=latest -e VARIANT=Silverblue ghcr.io/ublue-os/isogenerator:39
+```
+```bash
+# Requires sudo to run
+sudo podman run --rm --privileged --volume .:/isogenerator/output -e VERSION=39 -e IMAGE_NAME=silverblue-main -e IMAGE_TAG=latest -e VARIANT=Silverblue ghcr.io/ublue-os/isogenerator:39
 ```
 
-Creating Bazzite Latest ISO
+Creating Universal Blue Kinoite ISO
 ```bash
-docker run --rm --privileged --volume .:/isogenerator/output -e VERSION=39 -e IMAGE_NAME=bazzite -e IMAGE_TAG=latest -e VARIANT=Kinoite ghcr.io/ublue-os/isogenerator:39
+docker run --rm --privileged --volume .:/isogenerator/output -e VERSION=39 -e IMAGE_NAME=kinoite-main -e IMAGE_TAG=latest -e VARIANT=Kinoite ghcr.io/ublue-os/isogenerator:39
+```
+```bash
+# Requires sudo to run
+sudo podman run --rm --privileged --volume .:/isogenerator/output -e VERSION=39 -e IMAGE_NAME=kinoite-main -e IMAGE_TAG=latest -e VARIANT=Kinoite ghcr.io/ublue-os/isogenerator:39
 ```
 
 ## Customizing

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eu
+
+# pre-create loop devices manually. In containers we can't use losetup for that.
+mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
+
+make output/${IMAGE_NAME}-${IMAGE_TAG}.iso ARCH=${ARCH} VERSION=${VERSION} IMAGE_REPO=${IMAGE_REPO} IMAGE_NAME=${IMAGE_NAME} IMAGE_TAG=${IMAGE_TAG} VARIANT=${VARIANT} WEB_UI=${WEB_UI}


### PR DESCRIPTION
This creates the loop device during container runtime which allows lorax to build the ISO and not need to rely on a host provided device file.

Fixes: #22