### PR TITLE
feat: add action outputs

### DIFF
--- a/.github/workflows/test-iso.yml
+++ b/.github/workflows/test-iso.yml
@@ -48,6 +48,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build ISO
+        id: build-iso
         uses: ./
         with:
           ARCH: 'x86_64'
@@ -64,7 +65,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: base-main-${{ matrix.version }}${{ matrix.SECURE_BOOT_STRING }}.iso
-          path: end_iso/*
+          path: |
+            ${{ steps.build-iso.outputs.iso-path }}
+            ${{ steps.build-iso.outputs.checksum-path }}
           if-no-files-found: error
           retention-days: 0
           compression-level: 0

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ sudo podman run --rm --privileged --volume .:/isogenerator/output -e VERSION=39 
 ```
 
 ## Customizing
+
+### Inputs
+
 The following variables can be used to customize the create image.
 
 | Variable            | Description                                                  | Default Value          |
@@ -55,6 +58,16 @@ The following variables can be used to customize the create image.
 \*\*NOTE: ENROLLMENT_PASSWORD and SECURE_BOOT_KEY_URL are not required. They are only required if you are creating specific kernel modules or if you are using Universal Blue Kernel Modules.
 
 Our public key for our kmods is located here: https://github.com/ublue-os/akmods/raw/main/certs/public_key.der
+
+### Outputs
+
+This action outputs some useful values for you to use further on in your workflow.
+
+| Output | Description |
+| ------ | ----------- |
+| output-directory | The directory containing ISO and checksum files |
+| iso-path | The full path to the ISO file |
+| checksum-path | The full path to the checksum file |
 
 ## VSCode Dev Container
 There is a dev container configuration provided for development. By default it will use the existing container image available at `ghcr.io/ublue-os/isogenerator`, however, you can have it build a new image by editing `.devcontainer/devcontainer.json` and replacing `image` with `build`. `Ctrl+/` can be used to comment and uncomment blocks of code within VSCode.

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,14 @@ inputs:
     required: false
     default: ${{ github.ref }}
 
+outputs:
+  output-directory:
+    value: ${{ steps.final.outputs.OUTPUT_DIR }}
+  iso-path: 
+    value: ${{ steps.final.outputs.ISO_PATH }}
+  checksum-path: 
+    value: ${{ steps.final.outputs.CHECKSUM_PATH }} 
+
 runs:
   using: composite
   steps:
@@ -120,6 +128,7 @@ runs:
 
     - name: Create deploy.iso and generate sha256 checksum
       shell: bash
+      id: final
       run: |
         make ${{ inputs.IMAGE_NAME }}-${{ inputs.IMAGE_TAG || inputs.VERSION }}.iso \
           ARCH=${{ inputs.ARCH }} \
@@ -132,3 +141,7 @@ runs:
         mkdir end_iso
         sha256sum ${{ inputs.IMAGE_NAME }}-${{ inputs.IMAGE_TAG || inputs.VERSION }}.iso > ./end_iso/${{ inputs.IMAGE_NAME }}-${{ inputs.IMAGE_TAG || inputs.VERSION }}-CHECKSUM
         mv ${{ inputs.IMAGE_NAME }}-${{ inputs.IMAGE_TAG || inputs.VERSION }}.iso end_iso/
+        
+        echo "OUTPUT_DIR=$(realpath ./end_iso)" >> $GITHUB_OUTPUT
+        echo "ISO_PATH=$(realpath ./end_iso/${{ inputs.IMAGE_NAME }}-${{ inputs.IMAGE_TAG || inputs.VERSION }}.iso)" >> $GITHUB_OUTPUT
+        echo "CHECKSUM_PATH=$(realpath ./end_iso/${{ inputs.IMAGE_NAME }}-${{ inputs.IMAGE_TAG || inputs.VERSION }}-CHECKSUM)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Closes #42 

Creates action outputs pointing to the directory containing the built artifacts, the path to the ISO file and the path to the checksum file.
This has been documented in the README.md

I have also updated the CI job to use these outputs so we can validate it's all working as expected.