### PR TITLE
chore: small refactoring to CI build matrix jobs

### DIFF
--- a/.github/workflows/test-iso.yml
+++ b/.github/workflows/test-iso.yml
@@ -27,18 +27,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - 38
-          - 39
-        secure_boot:
-          - true
-          - false
+        version: [38, 39]
+        boot: [secureboot, insecure]
         include:
-          - secure_boot: true
+          - boot: secureboot
             SECURE_BOOT_KEY_URL: 'https://github.com/ublue-os/akmods/raw/main/certs/public_key.der'
             ENROLLMENT_PASSWORD: 'ublue-os'
             SECURE_BOOT_STRING: '-secure'
-          - secure_boot: false
+          - boot: insecure
             SECURE_BOOT_KEY_URL: ''
             ENROLLMENT_PASSWORD: ''
             SECURE_BOOT_STRING: ''


### PR DESCRIPTION
Should hopefully make the names a bit more meaningful and easy to understand.
This serves no real purpose, other than to make the GitHub UI look a bit prettier.

Instead of
```
Test Generate ISO / Build ISO (39, true)
```

We now have
```
Test Generate ISO / Build ISO (39, secureboot)
```