### PR TITLE
chore: remove ACTION_REF and ACTION_REPO action inputs

### DIFF
--- a/.github/workflows/test-iso.yml
+++ b/.github/workflows/test-iso.yml
@@ -52,8 +52,6 @@ jobs:
           IMAGE_REPO: 'ghcr.io/ublue-os'
           VARIANT: 'Kinoite'
           VERSION: ${{ matrix.version }}
-          ACTION_REPO: ${{ github.repository }}
-          ACTION_REF: ${{ github.ref }}
           SECURE_BOOT_KEY_URL: ${{ matrix.SECURE_BOOT_KEY_URL }}
           ENROLLMENT_PASSWORD: ${{ matrix.ENROLLMENT_PASSWORD }}
 

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,12 @@ inputs:
   SECURE_BOOT_KEY_URL:
     description: Secure boot key that is installed from URL location
     required: false
+  ACTION_REPO:
+    deprecationMessage: This variable is no longer required
+    required: false
+  ACTION_REF:
+    deprecationMessage: This variable is no longer required
+    required: false
 
 outputs:
   output-directory:

--- a/action.yml
+++ b/action.yml
@@ -76,9 +76,12 @@ runs:
 
     - name: Checkout repository
       uses: actions/checkout@v4
+      env:
+        ACTION_REF: ${{ github.action_ref }}
+        ACTION_REPO: ${{ github.action_repository }}
       with:
-        repository: ${{ github.action_repository }}
-        ref: ${{ github.action_ref }}
+        repository: $ACTION_REPO
+        ref: $ACTION_REF
         submodules: recursive
 
     - name: Install dependencies

--- a/action.yml
+++ b/action.yml
@@ -40,10 +40,10 @@ inputs:
     description: Secure boot key that is installed from URL location
     required: false
   ACTION_REPO:
-    deprecationMessage: This variable is no longer required
+    deprecationMessage: This variable is no longer used and will be removed in a future version
     required: false
   ACTION_REF:
-    deprecationMessage: This variable is no longer required
+    deprecationMessage: This variable is no longer used and will be removed in a future version
     required: false
 
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -39,14 +39,6 @@ inputs:
   SECURE_BOOT_KEY_URL:
     description: Secure boot key that is installed from URL location
     required: false
-  ACTION_REPO:
-    description: Repository with the build action
-    required: false
-    default: ${{ github.repository }}
-  ACTION_REF:
-    description: Repository ref for the build action
-    required: false
-    default: ${{ github.ref }}
 
 outputs:
   output-directory:
@@ -85,8 +77,8 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        repository: ${{ inputs.ACTION_REPO }}
-        ref: ${{ inputs.ACTION_REF }}
+        repository: ${{ github.github.action_repository }}
+        ref: ${{ github.action_ref }}
         submodules: recursive
 
     - name: Install dependencies

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ runs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        repository: ${{ github.github.action_repository }}
+        repository: ${{ github.action_repository }}
         ref: ${{ github.action_ref }}
         submodules: recursive
 

--- a/action.yml
+++ b/action.yml
@@ -70,22 +70,13 @@ runs:
           echo "Host must be mounted as /host in order to make more space"
         fi
         
-    - name: Install make and git
+    - name: Install Make
       shell: bash
-      run: dnf install -y make git
-
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      env:
-        ACTION_REF: ${{ github.action_ref }}
-        ACTION_REPO: ${{ github.action_repository }}
-      with:
-        repository: $ACTION_REPO
-        ref: $ACTION_REF
-        submodules: recursive
+      run: dnf install -y make
 
     - name: Install dependencies
       shell: bash
+      working-directory: ${{ github.action_path }}
       run: make install-deps
 
     - name: Lowercase Registry
@@ -96,6 +87,7 @@ runs:
 
     - name: Download image
       shell: bash
+      working-directory: ${{ github.action_path }}
       run: |
         make container/${{ inputs.IMAGE_NAME }}-${{ inputs.IMAGE_TAG || inputs.VERSION }} \
           ARCH=${{ inputs.ARCH }} \
@@ -108,6 +100,7 @@ runs:
 
     - name: Create boot.iso
       shell: bash
+      working-directory: ${{ github.action_path }}
       run: |
         make boot.iso \
           ARCH=${{ inputs.ARCH }} \
@@ -124,6 +117,7 @@ runs:
     - name: Create deploy.iso and generate sha256 checksum
       shell: bash
       id: final
+      working-directory: ${{ github.action_path }}
       run: |
         make ${{ inputs.IMAGE_NAME }}-${{ inputs.IMAGE_TAG || inputs.VERSION }}.iso \
           ARCH=${{ inputs.ARCH }} \


### PR DESCRIPTION
I don't think we need to pass these in.  By calling the action in the parent workflow, the code is all available on disk already.

Have left the inputs there but included a deprecationMessage explaining the inputs are no longer required.